### PR TITLE
Make the project compilable with SBT 0.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,3 @@ publishTo <<= version { v => Some {
 }}
 
 credentials += Credentials(Path.userHome / ".config" / "xsbt-sh" / "nexus.config")
-
-crossBuildingSettings
-
-CrossBuilding.crossSbtVersions := Seq("0.12", "0.13")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.0")


### PR DESCRIPTION
To this end, drop the dependency on sbt-cross-building. This way, one can use
the plugin on 0.13 without waiting for a release by declaring a source
dependency on a repo with this commit.
