### PR TITLE
Switch to SBT 0.13 (fixes #7)

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=0.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.0")
+addSbtPlugin("net.virtual-void" % "sbt-cross-building" % "0.8.1")


### PR DESCRIPTION
I just updated the version of sbt-cross-building, the other work was
already done; this seems to work now (tested with `sbt '^publishLocal'`,
which uses cross-building).

This does not fix the deprecation warnings, but it's not clear the
project would still compile with other SBTs.
